### PR TITLE
Add betting and folding features

### DIFF
--- a/src/components/Controls.jsx
+++ b/src/components/Controls.jsx
@@ -2,7 +2,8 @@ import React from 'react'
 import { usePoker } from '../context/PokerContext'
 
 const Controls = () => {
-  const { initializeGame, dealCommunityCards, phase } = usePoker()
+  const { initializeGame, dealCommunityCards, phase, placeBet, foldPlayer, players } = usePoker()
+  const player = players[0] || {}
 
   const canDeal = phase === 'pre-flop'
   const canAdvance = ['pre-flop', 'flop', 'turn', 'river'].includes(phase)
@@ -15,6 +16,18 @@ const Controls = () => {
         <button onClick={initializeGame} style={buttonStyle}>
           🔁 Deal New Game
         </button>
+      )}
+
+      {/* Betting */}
+      {phase !== 'showdown' && !player.folded && (
+        <>
+          <button onClick={() => placeBet(player.id, 10)} style={buttonStyle}>
+            💰 Bet 10
+          </button>
+          <button onClick={() => foldPlayer(player.id)} style={buttonStyle}>
+            🚪 Fold
+          </button>
+        </>
       )}
 
       {/* Advance Phase */}

--- a/src/components/PokerTable.jsx
+++ b/src/components/PokerTable.jsx
@@ -4,11 +4,12 @@ import Controls from './Controls'
 import Card from './Card'
 
 const PokerTable = () => {
-  const { players, communityCards, phase, winner } = usePoker()
+  const { players, communityCards, phase, winner, pot } = usePoker()
 
   return (
     <div>
       <h2>Phase: {phase}</h2>
+      <h3>Pot: {pot}</h3>
 
       {/* Community Cards */}
       <div style={{ display: 'flex', justifyContent: 'center',  margin: '1rem 0' }}>
@@ -32,9 +33,13 @@ const PokerTable = () => {
             }}
           >
             <strong>{player.name}</strong>
+            <div style={{ marginTop: '0.25rem' }}>Chips: {player.chips}</div>
             <div style={{ display: 'flex', justifyContent: 'center', marginTop: '0.5rem' }}>
               {player.cards.map((card, index) => (
-                <Card key={index} code={card.code} />
+                <Card
+                  key={index}
+                  code={player.id === 1 || phase === 'showdown' ? card.code : '🂠'}
+                />
               ))}
             </div>
           </div>


### PR DESCRIPTION
## Summary
- track a shared pot and player chip stacks
- hide opponent cards until showdown
- allow the player to bet or fold
- ignore folded players when deciding the winner

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*